### PR TITLE
define dmp_dv_get_pixel_size_byte()

### DIFF
--- a/include/cmdlist_ipu.hpp
+++ b/include/cmdlist_ipu.hpp
@@ -213,14 +213,14 @@ class CDMPDVCmdListIPUHelper : public CDMPDVCmdListKHelper {
       }
 
       // register buffers
-      uint64_t size = cmd->rect_width * cmd->rect_height * _GetPixelSize(cmd->fmt_wr);
+      uint64_t size = cmd->rect_width * cmd->rect_height * dmp_dv_get_pixel_size_byte(cmd->fmt_wr);
       output_bufs.push_back(std::make_pair(cmd->wr, size));
       if (cmd->use_rd) {
-        size = cmd->rect_width * cmd->rect_height * _GetPixelSize(cmd->fmt_rd);
+        size = cmd->rect_width * cmd->rect_height * dmp_dv_get_pixel_size_byte(cmd->fmt_rd);
         input_bufs.push_back(std::make_pair(cmd->rd, size));
       }
       if (cmd->use_tex) {
-        size = cmd->tex_width * cmd->tex_height * _GetPixelSize(cmd->fmt_tex);
+        size = cmd->tex_width * cmd->tex_height * dmp_dv_get_pixel_size_byte(cmd->fmt_tex);
         input_bufs.push_back(std::make_pair(cmd->tex, size));
       }
 
@@ -309,22 +309,6 @@ class CDMPDVCmdListIPUHelper : public CDMPDVCmdListKHelper {
       }
       return 0;
     };
-
-    /// @brief auxiliary function for CheckRaw_v0
-    static int _GetPixelSize(int img_fmt) {
-      switch (img_fmt) {
-        case DMP_DV_RGB888:
-          return 3;
-        case DMP_DV_RGBA8888:
-          return 4;
-        case DMP_DV_RGBFP16:
-          return 6;
-        case DMP_DV_LUT:
-          return 1;
-        default:
-          return -1;
-      }
-    }
 
     static uint32_t _f2fp24(float g)
     {

--- a/include/dmp_dv.h
+++ b/include/dmp_dv.h
@@ -335,6 +335,15 @@ int dmp_dv_pack_fc_weights(
 #define DMP_DV_RGBFP16    2 
 #define DMP_DV_LUT        7 
 
+/// @brief get pixel size in byte
+/// @param image_format must be one of the following
+///         - DMP_DV_RGBA8888 
+///         - DMP_DV_RGB888   
+///         - DMP_DV_RGBFP16  
+///         - DMP_DV_LUT      
+/// @return the size of pixel in byte if an appropriate parameter is given, -1 otherwise
+int dmp_dv_get_pixel_size_byte(int image_format);
+
 // uint8_t to fp16 conversion rule for IPU
 #define DMP_DV_CNV_FP16_SUB       0
 #define DMP_DV_CNV_FP16_DIV_255   1

--- a/src/dmp_dv.cpp
+++ b/src/dmp_dv.cpp
@@ -250,4 +250,19 @@ int dmp_dv_cmdlist_add_raw(dmp_dv_cmdlist cmdlist, struct dmp_dv_cmdraw *cmd) {
   return ((CDMPDVCmdList*)cmdlist)->AddRaw(cmd);
 }
 
+int dmp_dv_get_pixel_size_byte(int image_format) {
+  switch (image_format) {
+    case DMP_DV_RGB888:
+      return 3;
+    case DMP_DV_RGBA8888:
+      return 4;
+    case DMP_DV_RGBFP16:
+      return 6;
+    case DMP_DV_LUT:
+      return 1;
+    default:
+      return -1;
+  }
+}
+
 }  // extern "C"


### PR DESCRIPTION
API to get pixel size from DMP_DV_* image format macro