### PR TITLE
fix conv output size calculation

### DIFF
--- a/tests/test_conv/generate_data.py
+++ b/tests/test_conv/generate_data.py
@@ -129,7 +129,7 @@ class Main(object):
 
     def get_ox(self, width, kx, pad_left, pad_right, stride, deconv):
         return (pad_left + ((width - 1) * stride + 1 if deconv else width) +
-                pad_right - kx) / (1 if deconv else stride) + 1
+                pad_right - kx) // (1 if deconv else stride) + 1
 
     def generate(self, width, height, n_channels, kx, ky, n_kernels,
                  pad_ltrb, stride_xy, activation, dw, dil, deconv, args):


### PR DESCRIPTION
get_ox() sometimes returns floating value.